### PR TITLE
Augment permissions for NodePool to add DescribeImages

### DIFF
--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -187,6 +187,7 @@ const (
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeAddresses",
         "ec2:DescribeAvailabilityZones",
+		"ec2:DescribeImages",
         "ec2:DescribeInstances",
         "ec2:DescribeInternetGateways",
         "ec2:DescribeNatGateways",


### PR DESCRIPTION
+ In order to customize the root volume, the controller
  invokes DescribeImages at some point in the process.
  Without this permission, host provisioning will fail.