### PR TITLE
Add CLI options to expose nodepool volume customizations

### DIFF
--- a/api/fixtures/example.go
+++ b/api/fixtures/example.go
@@ -73,6 +73,9 @@ type ExampleAWSOptions struct {
 	KubeCloudControllerUserAccessKeySecret string
 	NodePoolManagementUserAccessKeyID      string
 	NodePoolManagementUserAccessKeySecret  string
+	RootVolumeSize                         int64
+	RootVolumeType                         string
+	RootVolumeIOPS                         int64
 }
 
 func (o ExampleOptions) Resources() *ExampleResources {
@@ -283,6 +286,11 @@ aws_secret_access_key = %s
 					{
 						ID: &o.AWS.SecurityGroupID,
 					},
+				},
+				RootVolume: &hyperv1.Volume{
+					Size: o.AWS.RootVolumeSize,
+					Type: o.AWS.RootVolumeType,
+					IOPS: o.AWS.RootVolumeIOPS,
 				},
 			}
 		}

--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -44,6 +44,9 @@ type Options struct {
 	Annotations        []string
 	NetworkType        string
 	FIPS               bool
+	RootVolumeType     string
+	RootVolumeIOPS     int64
+	RootVolumeSize     int64
 }
 
 func NewCreateCommand() *cobra.Command {
@@ -79,6 +82,9 @@ func NewCreateCommand() *cobra.Command {
 		Annotations:        []string{},
 		NetworkType:        string(v1alpha1.OpenShiftSDN),
 		FIPS:               false,
+		RootVolumeType:     "gp2",
+		RootVolumeSize:     16,
+		RootVolumeIOPS:     0,
 	}
 
 	cmd.Flags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "A namespace to contain the generated resources")
@@ -98,6 +104,9 @@ func NewCreateCommand() *cobra.Command {
 	cmd.Flags().StringArrayVar(&opts.Annotations, "annotations", opts.Annotations, "Annotations to apply to the hostedcluster (key=value). Can be specified multiple times.")
 	cmd.Flags().StringVar(&opts.NetworkType, "network-type", opts.NetworkType, "Enum specifying the cluster SDN provider. Supports either Calico or OpenshiftSDN.")
 	cmd.Flags().BoolVar(&opts.FIPS, "fips", opts.FIPS, "Enables FIPS mode for nodes in the cluster")
+	cmd.Flags().StringVar(&opts.RootVolumeType, "root-volume-type", opts.RootVolumeType, "The type of the root volume (e.g. gp2, io1) for machines in the NodePool")
+	cmd.Flags().Int64Var(&opts.RootVolumeIOPS, "root-volume-iops", opts.RootVolumeIOPS, "The iops of the root volume when specifying type:io1 for machines in the NodePool")
+	cmd.Flags().Int64Var(&opts.RootVolumeSize, "root-volume-size", opts.RootVolumeSize, "The size of the root volume (default: 16, min: 8) for machines in the NodePool")
 
 	cmd.MarkFlagRequired("pull-secret")
 	cmd.MarkFlagRequired("aws-creds")
@@ -240,6 +249,9 @@ func CreateCluster(ctx context.Context, opts Options) error {
 			KubeCloudControllerUserAccessKeySecret: iamInfo.KubeCloudControllerUserAccessKeySecret,
 			NodePoolManagementUserAccessKeyID:      iamInfo.NodePoolManagementUserAccessKeyID,
 			NodePoolManagementUserAccessKeySecret:  iamInfo.NodePoolManagementUserAccessKeySecret,
+			RootVolumeSize:                         opts.RootVolumeSize,
+			RootVolumeType:                         opts.RootVolumeType,
+			RootVolumeIOPS:                         opts.RootVolumeIOPS,
 		},
 	}.Resources().AsObjects()
 


### PR DESCRIPTION
Support new options for `hypershift create cluster|nodepool`:

```
$ hypershift create cluster --help | grep root 
      --root-volume-iops int       The iops of the root volume when specifying type:io1 for machines in the NodePool
      --root-volume-size int       The size of the root volume (default: 16, min: 8) for machines in the NodePool (default 16)
      --root-volume-type string    The type of the root volume (e.g. gp2, io1) for machines in the NodePool (default "gp2")

$ hypershift create nodepool --help | grep root
      --root-volume-iops int      The iops of the root volume when specifying type:io1 for machines in the NodePool
      --root-volume-size int      The size of the root volume (default: 16, min: 8) for machines in the NodePool (default 16)
      --root-volume-type string   The type of the root volume (e.g. gp2, io1) for machines in the NodePool (default "gp2")
```